### PR TITLE
Fix: Missing fields when not triggered via API Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ You can always find your Moesif Application Id at any time by logging
 into the [_Moesif Portal_](https://www.moesif.com/), click on the top right menu,
  and then clicking _Installation_.
 
+### 3. Trigger your API
+Grab the URL to your API Gateway or LB and make some calls using a tool like Postman or CURL. 
+
+> In order for your event to log to Moesif, you must test using the Amazon API Gateway trigger. Do not invoke your lambda directly using AWS Console as the payload won't contain a valid HTTP payload.  
+
 ## Repo file structure
 
 - `moesif_aws_lambda/middleware.py` the middleware library

--- a/moesif_aws_lambda/client_ip.py
+++ b/moesif_aws_lambda/client_ip.py
@@ -93,7 +93,7 @@ class ClientIp:
                 return default_source_ip
             else:
                 return None
-        except KeyError:
+        except Exception:
             if default_source_ip:
                 return default_source_ip
             else:

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.1.0',
+    version='1.2.0',
 
     description='Moesif Middleware to automatically log API calls from AWS Lambda functions',
     long_description=long_description,


### PR DESCRIPTION
If using tester within API Gateway console, then incoming event may not be a valid HTTP payload. Handle gracefully instead of error.